### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,7 +7,7 @@
 #######################################
 
 Pin	KEYWORD1
-Log KEYWORD1
+Log	KEYWORD1
 
 #######################################
 # Datatypes (KEYWORD2)
@@ -18,10 +18,10 @@ Log KEYWORD1
 #######################################
 
 #Pin
-setMode KEYWORD2
-fade KEYWORD2
-getPin KEYWORD2
+setMode	KEYWORD2
+fade	KEYWORD2
+getPin	KEYWORD2
 
 #Log
-debug KEYWORD2
-info KEYWORD2
+debug	KEYWORD2
+info	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords