### PR TITLE
Use semver compliant version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ paragraph=Use this library to make your code clean, beautiful, and fast
 category=Uncategorized
 url=http://kj415j45.space/kjArduino
 architectures=*
-version=v0.0.1~Arduino_*
+version=0.0.1-Arduino
 core-dependencies=*


### PR DESCRIPTION
Non-semver compliant `version` value causes the Arduino IDE to display warnings:
```
Invalid version found: v0.0.1~Arduino_*
```
This can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

References:
- https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format
- https://semver.org/